### PR TITLE
Enable submodules when building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Build only 
         uses: shalzz/zola-deploy-action@v0.18.0
         env:


### PR DESCRIPTION
Enable Git submodules when building in CI.
Should fix https://github.com/nomacs/nomacs.github.io/issues/5.