### PR TITLE
Change base path

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 # The URL the site will be built for
-base_url = "https://nomacs.org"
+base_url = "https://nomacs.github.io"
 title = "nomacs"
 description = "nomacs is a free, open source image viewer, which supports multiple platforms"
 


### PR DESCRIPTION
As the resulting site is hosted as a github page, it might be easier to manage to make the base path points to the github page and let the DNS settings do the custom domain stuff.

This should fix the JavaScript and CSS not loading and internal link directs to nomacs.org issue.

Fixes https://github.com/nomacs/nomacs.github.io/issues/6.