### PR TITLE
put back the about Windows build 3.17.2289

### DIFF
--- a/static/version/version_win_stable
+++ b/static/version/version_win_stable
@@ -1,0 +1,5 @@
+version 3.17.2289
+x64 https://github.com/nomacs/nomacs/releases/download/3.17.2287/nomacs-setup-x64.msi
+x86 https://github.com/nomacs/nomacs/releases
+mac https://github.com/nomacs/nomacs/releases
+XPx86 https://github.com/nomacs/nomacs/releases


### PR DESCRIPTION
This PR returns the windows version file that was initially added by @novomesk in 3eef4f2fa36d6c93c0c87f11105c5573ab2281ba and was accidentally removed while migrating to new theme.