### PR TITLE
Replace travis mention

### DIFF
--- a/content/docs/contributing/how-to-contribute.md
+++ b/content/docs/contributing/how-to-contribute.md
@@ -48,7 +48,7 @@ We will comment on pull requests within one week. Here are some things that incr
 
 - Write good commit messages.
 - Follow our style guide.
-- Don't break the [Travis](https://travis-ci.org/nomacs/nomacs) build.
+- Pass all the Github action checks.
 
 ### Style
 


### PR DESCRIPTION
Travis was replaced by github actions in
https://github.com/nomacs/nomacs/pull/1103.
Replace the travis mention.